### PR TITLE
gitignore の変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /local.properties
 /.idea/caches
 /.idea/libraries
+/.idea/dictionaries
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml


### PR DESCRIPTION
## PR 概要

`.idea/dictionaries` ディレクトリは git 管理不要なので gitignore に追加。