### PR TITLE
Book モデルの名前を変更。

### DIFF
--- a/app/src/main/java/com/example/bookmanager/models/BookSearchResult.kt
+++ b/app/src/main/java/com/example/bookmanager/models/BookSearchResult.kt
@@ -1,6 +1,6 @@
 package com.example.bookmanager.models
 
-data class Book (
+data class BookSearchResult (
     val id: String,
     val title: String,
     val authors: List<String>,

--- a/app/src/main/java/com/example/bookmanager/utils/BindingAdapters.kt
+++ b/app/src/main/java/com/example/bookmanager/utils/BindingAdapters.kt
@@ -2,13 +2,13 @@ package com.example.bookmanager.utils
 
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.example.bookmanager.models.Book
+import com.example.bookmanager.models.BookSearchResult
 import com.example.bookmanager.views.BookSearchAdapter
 
 object BindingAdapters {
     @JvmStatic
     @BindingAdapter("resultBooks")
-    fun RecyclerView.bindResultBooks(resultBooks: List<Book>?) {
+    fun RecyclerView.bindResultBooks(resultBooks: List<BookSearchResult>?) {
         resultBooks ?: return
         (adapter as BookSearchAdapter).update(resultBooks)
     }

--- a/app/src/main/java/com/example/bookmanager/viewmodels/BookResultViewModel.kt
+++ b/app/src/main/java/com/example/bookmanager/viewmodels/BookResultViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.bookmanager.databinding.ActivityBookSearchBinding
 import com.example.bookmanager.models.Item
-import com.example.bookmanager.models.Book
+import com.example.bookmanager.models.BookSearchResult
 import com.example.bookmanager.models.SearchResult
 import com.example.bookmanager.utils.Const
 import com.mancj.materialsearchbar.MaterialSearchBar
@@ -16,14 +16,14 @@ import java.io.IOException
 
 class BookResultViewModel : ViewModel() {
 
-    private val _resultBooks: MutableLiveData<List<Book>> = MutableLiveData()
-    val resultBooks: LiveData<List<Book>> = _resultBooks
+    private val _resultBooks: MutableLiveData<List<BookSearchResult>> = MutableLiveData()
+    val resultBooks: LiveData<List<BookSearchResult>> = _resultBooks
 
     private var searchCallback: SearchCallback? = null
 
     interface SearchCallback {
         fun onSearchStart()
-        fun onSearchSucceeded(resultBooks: List<Book>)
+        fun onSearchSucceeded(resultBooks: List<BookSearchResult>)
         fun onSearchFailed()
     }
 
@@ -89,8 +89,8 @@ class BookResultViewModel : ViewModel() {
         }
     }
 
-    private fun createResultBooks(items: List<Item>): List<Book> {
-        val books = mutableListOf<Book>()
+    private fun createResultBooks(items: List<Item>): List<BookSearchResult> {
+        val books = mutableListOf<BookSearchResult>()
         for (item in items) {
             val info = item.volumeInfo
             val id = item.id
@@ -113,7 +113,7 @@ class BookResultViewModel : ViewModel() {
                 ""
             }
 
-            books.add(Book(id, title, authors, image))
+            books.add(BookSearchResult(id, title, authors, image))
         }
         return books
     }

--- a/app/src/main/java/com/example/bookmanager/views/BookSearchActivity.kt
+++ b/app/src/main/java/com/example/bookmanager/views/BookSearchActivity.kt
@@ -115,7 +115,7 @@ class BookSearchActivity : AppCompatActivity() {
                     showProgressBar()
                 }
 
-                override fun onSearchSucceeded(resultBooks: List<com.example.bookmanager.models.Book>) {
+                override fun onSearchSucceeded(resultBooks: List<com.example.bookmanager.models.BookSearchResult>) {
                     hideProgressBar()
                     clearFocus()
                     if (resultBooks.isEmpty()) {
@@ -155,7 +155,7 @@ class BookSearchActivity : AppCompatActivity() {
         }
     }
 
-    inner class OnOkButtonClickListener(private val resultBook: com.example.bookmanager.models.Book) :
+    inner class OnOkButtonClickListener(private val resultBook: com.example.bookmanager.models.BookSearchResult) :
         DialogInterface.OnClickListener {
 
         override fun onClick(dialog: DialogInterface?, which: Int) {

--- a/app/src/main/java/com/example/bookmanager/views/BookSearchAdapter.kt
+++ b/app/src/main/java/com/example/bookmanager/views/BookSearchAdapter.kt
@@ -10,13 +10,13 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.bookmanager.R
 import com.example.bookmanager.databinding.ListItemBookSearchBinding
-import com.example.bookmanager.models.Book
+import com.example.bookmanager.models.BookSearchResult
 import com.example.bookmanager.utils.Libs
 
 class BookSearchAdapter : RecyclerView.Adapter<BookSearchAdapter.BookSearchViewHolder>() {
 
     private lateinit var context: Context
-    private var resultBooks: List<Book> = listOf()
+    private var resultBooks: List<BookSearchResult> = listOf()
     private var listener: View.OnClickListener? = null
 
     fun setListener(listener: View.OnClickListener) {
@@ -51,7 +51,7 @@ class BookSearchAdapter : RecyclerView.Adapter<BookSearchAdapter.BookSearchViewH
         return resultBooks.size
     }
 
-    fun update(resultBooks: List<Book>) {
+    fun update(resultBooks: List<BookSearchResult>) {
         this.resultBooks = resultBooks
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/bookmanager/views/BookshelfAdapter.kt
+++ b/app/src/main/java/com/example/bookmanager/views/BookshelfAdapter.kt
@@ -10,12 +10,12 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.example.bookmanager.R
 import com.example.bookmanager.databinding.ListItemBookshelfBinding
-import com.example.bookmanager.models.Book
+import com.example.bookmanager.models.BookSearchResult
 
 class BookshelfAdapter() : RecyclerView.Adapter<BookshelfAdapter.BookShelfHolder>() {
 
     lateinit var context: Context
-    private val books: List<Book> = fetchBooks()
+    private val books: List<BookSearchResult> = fetchBooks()
     private var listener: View.OnClickListener? = null
 
     fun setListener(listener: View.OnClickListener) {
@@ -52,19 +52,19 @@ class BookshelfAdapter() : RecyclerView.Adapter<BookshelfAdapter.BookShelfHolder
     /**
      * DB から本棚に登録されている本の情報を取得する。
      */
-    private fun fetchBooks(): List<Book> {
+    private fun fetchBooks(): List<BookSearchResult> {
         return createDummyData()
     }
 
-    private fun createDummyData(): MutableList<Book> {
-        val books = mutableListOf<Book>()
+    private fun createDummyData(): MutableList<BookSearchResult> {
+        val books = mutableListOf<BookSearchResult>()
         for (i in 1..10) {
             val id = "abc"
             val image =
                 "http://books.google.com/books/content?id=13gDwgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
             val title = "鬼滅の刃(${i})"
             val authors = arrayListOf("吾峠呼世晴", "TEST")
-            books.add(Book(id, title, authors, image))
+            books.add(BookSearchResult(id, title, authors, image))
         }
         return books
     }


### PR DESCRIPTION
## RP 概要

Book モデルの名前を BookSearchResult に変更。
Book はデータベースのエンティティ名としても使用しているため、混乱を避ける目的で変更。